### PR TITLE
Update SSL Ciphers for nginx.conf

### DIFF
--- a/src/rpm/conf/nginx.conf
+++ b/src/rpm/conf/nginx.conf
@@ -37,7 +37,8 @@ http {
 
 
     # SSL PCI Compliance
-    ssl_ciphers                 RC4:HIGH:!aNULL:!MD5:!kEDH;
+    ssl_protocols               TLSv1.2 TLSv1.1 TLSv1;
+    ssl_ciphers                 EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
     ssl_session_cache           shared:SSL:10m;
     ssl_prefer_server_ciphers   on;
 


### PR DESCRIPTION
To fix RC4 immediate deprecation by major web browsers. Using old configuration results in "Insecure Certificate" errors.

Strong Ciphers via CloudFlare (https://github.com/cloudflare/sslconfig/blob/master/conf).
Excluded CloudFlare's use of ChaCha cipher due to compatibility patch required.

Info Source:
- https://tools.ietf.org/html/rfc7465
- https://www.pcicomplianceguide.org/pci-dss-v3-1-and-ssl-what-you-should-do-now/
- https://blog.digicert.com/major-browsers-announce-rc4-deprecation/
